### PR TITLE
feat: add Access Account screen and update Onboarding and Signup layouts

### DIFF
--- a/app/src/main/res/drawable/shape_bullet_unselected.xml
+++ b/app/src/main/res/drawable/shape_bullet_unselected.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/color_secondary_grey" />
+    <solid android:color="@color/deactivated_color" />
     <corners android:radius="16dp" />
 </shape>

--- a/app/src/main/res/layout/activity_access_account2.xml
+++ b/app/src/main/res/layout/activity_access_account2.xml
@@ -56,79 +56,73 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <!-- Indicadores -->
+            <!-- Texto y body -->
             <LinearLayout
-                android:id="@+id/indicator_container"
-                android:layout_width="wrap_content"
+                android:id="@+id/ll_access_account_text"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="48dp"
+                android:orientation="vertical"
                 android:gravity="center"
-                android:orientation="horizontal"
-                android:layout_marginTop="24dp"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent">
 
-                <ImageView
-                    android:id="@+id/indicator1"
-                    android:layout_width="12dp"
-                    android:layout_height="match_parent"
-                    android:layout_marginEnd="8dp"
-                    android:background="@drawable/selector_bullet" />
-
-                <ImageView
-                    android:id="@+id/indicator2"
-                    android:layout_width="12dp"
-                    android:layout_height="8dp"
-                    android:layout_marginEnd="8dp"
-                    android:background="@drawable/selector_bullet" />
-
-                <ImageView
-                    android:id="@+id/indicator3"
-                    android:layout_width="12dp"
-                    android:layout_height="8dp"
-                    android:background="@drawable/selector_bullet" />
-            </LinearLayout>
-
-            <!-- Texto y botón -->
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:orientation="vertical"
-                android:gravity="center"
-                app:layout_constraintTop_toBottomOf="@id/indicator_container"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent">
-
                 <TextView
-                    android:id="@+id/tv_onboarding_title"
+                    android:id="@+id/tv_access_account_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     style="@style/title_onboarding"
-                    android:text="@string/onboarding_one_title" />
+                    android:text="@string/access_account_title" />
 
                 <TextView
-                    android:id="@+id/tv_onboarding_body"
+                    android:id="@+id/tv_access_account_body"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"
                     android:layout_marginHorizontal="24dp"
                     style="@style/text_body"
-                    android:text="@string/onboarding_one_body" />
+                    android:text="@string/access_account_body" />
 
-                <ImageButton
-                    android:id="@+id/btn_next"
-                    android:layout_width="54dp"
-                    android:layout_height="54dp"
-                    android:layout_marginTop="24dp"
-                    android:background="@drawable/rounded_next_button"
-                    android:backgroundTint="@color/color_main"
-                    android:contentDescription="@string/next_button"
-                    android:src="@drawable/baseline_arrow_forward_ios_24"
-                    android:scaleType="centerInside"
-                    android:padding="12dp"
-                    app:tint="@color/white" />
             </LinearLayout>
+
+            <!-- LinearLayout para botón y enlace -->
+            <LinearLayout
+                android:id="@+id/ll_access_account_button_and_link"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/ll_access_account_text"
+                android:layout_marginTop="24dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginEnd="20dp">
+
+                <!-- Botón: Iniciar sesión -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/bt_access_account_signup"
+                    style="@style/button_solid_16dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:backgroundTint="@color/color_main"
+                    android:padding="18dp"
+                    android:text="@string/access_account_bt_signup"
+                    app:cornerRadius="16dp" />
+
+                <!-- Texto enlace -->
+                <TextView
+                    android:id="@+id/tv_access_account_login"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:text="@string/access_account_login"
+                    style="@style/text_link_underlined"
+                    android:textColor="@color/color_secondary_grey"/>
+
+            </LinearLayout>
+
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -224,6 +224,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="20dp"
                 android:layout_marginEnd="20dp"
+                android:layout_marginTop="6dp"
                 android:gravity="center_vertical"
                 android:orientation="horizontal"
                 app:boxBackgroundMode="none"
@@ -231,12 +232,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/bt_signup_button">
 
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="6dp"
-                    android:gravity="center_vertical"
-                    android:orientation="horizontal">
+
 
                     <TextView
                         android:id="@+id/tv_terms"
@@ -252,7 +248,7 @@
                         android:layout_height="wrap_content"
                         android:layout_marginStart="4dp"
                         android:text="@string/terms_url" />
-                </LinearLayout>
+
             </LinearLayout>
 
             <!-- Bloque de otras formas de inicio sesión -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,7 +8,6 @@
     <color name="color_secondary_blue">#73ACB5</color>
     <color name="color_secondary_orange">#FBBB73</color>
     <color name="color_secondary_wine">#B56974</color>
-    <color name="activated_color">#32788C</color>
-    <color name="deactivated_color">#8E8888</color>
+    <color name="deactivated_color">#7FA7B5</color>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,9 +49,10 @@
 
     <!--    Access Account   -->
     <!-- Strings reutilizables usados: reusable_register, reusable_login -->
-    <string name="access_account_title">Tu aventura \n acaba de empezar</string>
+    <string name="access_account_title">Empieza ya</string>
+    <string name="access_account_body">Tu aventura está a punto de empezar</string>
     <string name="access_account_bt_signup">@string/reusable_register</string>
-    <string name="access_account_bt_login">@string/reusable_login</string>
+    <string name="access_account_login">Conéctate</string>
 
     <!--    Login   -->
     <!-- Strings reutilizables usados: google_outlook, content_desc_google, content_desc_outlook, reusable_email, reusable_password, reusable_login -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -40,30 +40,18 @@
 
     </style>
 
-    <!--    Título onboarding  black 35sp -->
+    <!--    Título onboarding  35sp -->
     <style name="title_onboarding" parent="TextAppearance.AppCompat">
         <item name="android:layout_width">0dp</item> <!-- Se adapta con ConstraintLayout -->
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:textSize">35sp</item>
-        <item name="android:textFontWeight">900</item>
+        <item name="android:textSize">36sp</item>
+        <item name="android:textFontWeight">800</item>
         <item name="android:gravity">center</item>
+        <item name="android:textColor">@color/black</item>
+
 
     </style>
 
-    <!-- Onboarding 1 -->
-    <style name="title_onboarding_one" parent="title_onboarding">
-        <item name="android:textColor">@color/color_secondary_blue</item>
-    </style>
-
-    <!-- Onboarding 2 -->
-    <style name="title_onboarding_two" parent="title_onboarding">
-        <item name="android:textColor">@color/color_secondary_orange</item>
-    </style>
-
-    <!-- Onboarding 3 -->
-    <style name="title_onboarding_three" parent="title_onboarding">
-        <item name="android:textColor">@color/color_secondary_wine</item>
-    </style>
 
 
     <!--    subtítulo 16sp-->
@@ -79,10 +67,13 @@
 
     <style name="text_body" parent="TextAppearance.AppCompat">
         <item name="android:textSize">20sp</item>
-        <item name="android:textColor">@color/black</item>
+        <item name="android:textColor">@color/color_secondary_grey</item>
         <item name="android:textFontWeight">400</item>
         <item name="android:gravity">center</item>
     </style>
+
+
+
 
     <!--    Título H3 14dp   -->
     <style name="title_h3_14dp" parent="TextAppearance.AppCompat">


### PR DESCRIPTION
This commit introduces the Access Account screen and updates the layouts for Onboarding and Signup activities.

**Access Account screen:**
-   Created a new layout `activity_access_account2.xml` for change the Access Account screen.
-   Added a title, body, sign-up button, and a login link.
- Added close button in the top left corner.

**Onboarding screen:**
-   Modified `activity_onboarding.xml`.
- Changed indicator height.
- Changed style title onboarding.

**Signup screen:**
-   Modified `activity_signup.xml`.
-   Added margin top to the terms and policy section.

**Styles:**
-    Updated the `title_onboarding` style to be more generic, removing specific color variations.
- Removed style onborading 1,2,3
- Updated style Text body
-   Updated colors: color bullet unselect.

**Other:**
- New string for body text in access account.
- Update string login text.